### PR TITLE
API Wrapper module and base objects

### DIFF
--- a/coronado-triple-api-wrapper/pom.xml
+++ b/coronado-triple-api-wrapper/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.coronado-fi</groupId>
+        <artifactId>coronado-jvm</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.github.coronado-fi.coronado-jvm</groupId>
+    <artifactId>coronado-triple-api-wrapper</artifactId>
+
+    <properties/>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.moshi</groupId>
+            <artifactId>moshi</artifactId>
+            <version>${dependency.moshi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.moshi</groupId>
+            <artifactId>moshi-kotlin</artifactId>
+            <version>${dependency.moshi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+            <!-- define exclusions for junit-jupiter for now sine kotlin-test-junit5 declares older versions for
+                 junit-jupiter dependencies.  Newer junit-jupiter versions will be defined explicitly. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${dependency.junit-jupiter-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.gantsign.maven</groupId>
+                <artifactId>ktlint-maven-plugin</artifactId>
+                <version>${ktlint-maven-plugin.version}</version>
+                <executions>
+                    <!-- Only use ktlint "check" goal (no formatting), and bind to "validate" phase rather than the
+                         default "verify" phase -->
+                    <execution>
+                        <id>validation-check</id>
+                        <!--<phase>verify</phase>-->
+                        <phase>validate</phase>
+                        <goals>
+                            <!--<goal>format</goal>-->
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skip>${ktlint.skip}</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forkCount>${failsafe.forkCount}</forkCount>
+                    <skip>${maven.integration.test.skip}</skip>
+                    <useSystemClassLoader>${failsafe.useSystemClassLoader}</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>${surefire.forkCount}</forkCount>
+                    <skip>${maven.test.skip}</skip>
+                    <useSystemClassLoader>${surefire.useSystemClassLoader}</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <!-- Explicitly bind kotlin-maven-plugin compile/test-compile goals to process-sources/process-test-sources
+                 phases so that it runs before maven-compile-plugin -->
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/JsonAdapters.kt
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/JsonAdapters.kt
@@ -1,0 +1,64 @@
+package io.github.coronado.api
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.util.Currency
+
+/**
+ * Singleton adapter objects used for JSON serialization
+ *
+ * @author Coronado Project Team
+ */
+
+object BigDecimalAdapter {
+    @FromJson
+    fun fromJson(string: String) = BigDecimal(string)
+
+    @ToJson
+    fun toJson(value: BigDecimal) = value.toString()
+}
+
+object CurrencyAdapter {
+    @FromJson
+    fun fromJson(string: String) = Currency.getInstance(string)
+
+    @ToJson
+    fun toJson(value: Currency) = value.toString()
+}
+
+object ZonedDateTimeAdapter {
+    @FromJson
+    fun fromJson(string: String) = ZonedDateTime.parse(string)
+
+    @ToJson
+    fun toJson(value: ZonedDateTime) = value.toString()
+}
+
+object LocalDateTimeAdapter {
+    @FromJson
+    fun fromJson(string: String) = LocalDateTime.parse(string)
+
+    @ToJson
+    fun toJson(value: LocalDateTime) = value.toString()
+}
+
+object LocalDateAdapter {
+    @FromJson
+    fun fromJson(string: String) = LocalDate.parse(string)
+
+    @ToJson
+    fun toJson(value: LocalDate) = value.toString()
+}
+
+object LocalTimeAdapter {
+    @FromJson
+    fun fromJson(string: String) = LocalTime.parse(string)
+
+    @ToJson
+    fun toJson(value: LocalTime) = value.toString()
+}

--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/package-info.java
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains the various Coronado API definitions.
+ *
+ * @author Coronado Project Team
+ */
+package io.github.coronado.api;

--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/baseobjects/BaseObjects.kt
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/baseobjects/BaseObjects.kt
@@ -1,0 +1,195 @@
+package io.github.coronado.baseobjects
+
+import com.squareup.moshi.Json
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.util.Currency
+
+/**
+ * Example data classes used for prototyping kotlin representations of Triple/Coronado API data objects
+ *
+ * @author Coronado Project Team
+ */
+
+// define objects with fields, camelcase the properties, assign datatypes, assign nullability
+
+data class Address(
+    @Json(name = "complete_address") val completeAddress: String, // The complete address, as would be written out for mail delivery or route navigation. ex: "7370 BAKER ST STE 100\nPITTSBURGH, PA 15206"
+    @Json(name = "line_1") val line1: String?, // ex: "7370 BAKER ST STE 100"
+    @Json(name = "line_2") val line2: String?,
+    val locality: String?, // City or locality name, ex: "PITTSBURGH"
+    val province: String, // State abbreviation or province name, ex: "PA"
+    @Json(name = "postal_code") val postalCode: String?, // ZIP Code™, ZIP+4, or postal code, ex: "15206"
+    @Json(name = "country_code") val countryCode: String?, // 2-letter ISO-3166 country code, ex: "US"
+    val latitude: Latitude,
+    val longitude: Longitude
+)
+
+typealias Latitude = BigDecimal
+typealias Longitude = BigDecimal
+
+data class CardAccount(
+    val id: String,
+    val cardProgramId: String,
+    @Json(name = "externalId") val cardAccountExternalId: String,
+    val status: CardAccountStatus,
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime
+)
+
+enum class CardAccountStatus { ENROLLED, NOT_ENROLLED, CLOSED }
+
+data class CardAccountIdentifier(
+    val publisherExternalId: String,
+    val cardProgramExternalId: String,
+    @Json(name = "externalId") val cardAccountExternalId: String,
+    val status: CardAccountStatus
+)
+
+data class CardProgram(
+    val id: String,
+    val publisherId: String,
+    val externalId: String,
+    val name: String,
+    val programCurrency: Currency,
+    val cardBins: Set<String>,
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime
+)
+
+data class MerchantCategoryCode(
+    val code: String,
+    val description: String
+)
+
+data class MerchantLocation(
+    val id: String,
+    val locationName: String,
+    val online: Boolean,
+    @Json(name = "email") val emailAddress: String,
+    val phoneNumber: String,
+    val address: Address
+)
+
+data class Offer(
+    val id: String,
+    val activationRequired: Boolean, // is this really true/false ?
+    val activationDurationInDays: Int, // is this integer or decimal ?
+    val currencyCode: Currency,
+    val category: String, // define this as an enum?  sample value: "AUTOMOTIVE"
+    val categoryTags: String, // should this be a collection ?
+    val categoryMccs: Set<String>, // should this be a collection of an embedded object type?
+    val description: String,
+    val effectiveDate: String, // should this be a tz-aware instant type ?
+    val excludedDates: Set<String>, // should this be a collection of tz-aware instant type?
+    val expirationDate: String, // should this be a tz-aware instant type?
+    val activated: Boolean,
+    val headline: String,
+    val maxRedemptions: String, // yuck  ex: "1/3M"
+    val maximumRewardPerTransaction: Int,
+    val maximumRewardCumulative: Int,
+    val merchantCategoryCode: MerchantCategoryCode,
+    val merchantName: String,
+    val merchantLogoUrl: String,
+    val minimumSpend: BigDecimal,
+    val mode: String, // is there an enum for this?   ex: "ONLINE"
+    val rewardRate: Int,
+    val rewardValue: BigDecimal,
+    val rewardType: String, // ex: "CARD_LINKED"
+    val type: String, // vague property name!     ex: "CARD_LINKED"
+    val validDayParts: String, // this is some kind of embedded object type {},
+    val termsAndConditions: String,
+    val merchantWebsite: String
+)
+
+data class OfferActivation(
+    val id: String,
+    val cardAccountId: String,
+    val activatedAt: String, // should this be a tz-aware instant type? ex: "2019-08-24"
+    val activationExpiresOn: String, // should this be a tz-aware instant type? ex: "2019-08-24"
+    val offer: Offer,
+    val merchant: String // this should be a type ? {"name": "string","logo_url": "string" }
+)
+
+data class DisplayRules(
+    val id: String,
+    val description: String,
+    val enabled: Boolean,
+    val scope: DisplayRuleScope, // this should be some embedded type? { "level": "PORTFOLIO_MANAGER", "id": "triple-abc-123", "name": "string"  },
+    val type: String, // some enum?  better property name? ex: "MERCHANT_NAME_EQUAL_TO"
+    val value: String, // this is supposed to be some numeric value?
+    val action: String // some enum?  "EXCLUDE"
+)
+
+data class DisplayRuleScope(
+    val id: String,
+    val level: String,
+    val name: String
+)
+
+data class Publisher(
+    val id: String,
+    val portfolioManagerId: String,
+    @Json(name = "externalId") val publisherExternalId: String,
+    val assumedName: String,
+    val address: Address,
+    val revenueShare: BigDecimal,
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime
+)
+
+data class Reward(
+    val transactionId: String,
+    val offerId: String, // maybe this should be an Offer type
+    val offerExternalId: String,
+    val transactionDate: ZonedDateTime,
+    val cardBin: String,
+    val cardLast4: String,
+    val transactionAmount: BigDecimal,
+    val transactionCurrencyCode: Currency,
+    val rewardAmount: BigDecimal,
+    val rewardCurrencyCode: String, //  there's dedicated type for this?
+    val offerHeadline: String,
+    val merchantName: String,
+    val merchantCompleteAddress: String,
+    val status: String // should this be an enum?  "REJECTED"
+)
+
+data class RewardDetail(
+    val offerId: String,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val status: String, // should this be an enum?  "REJECTED"
+    val rejection: String, // should this be an enum? ex:"PURCHASE_AMOUNT_TOO_LOW"
+    val notes: String
+)
+
+data class Transaction(
+    val id: String,
+    val cardAccountId: String,
+    @Json(name = "externalId") val transactionExternalId: String,
+    val localDate: LocalDate,
+    val localTime: LocalTime,
+    val debit: Boolean,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val transactionType: TransactionType,
+    val description: String,
+    val merchantCategoryCode: MerchantCategoryCode,
+    val merchantAddress: Address,
+    val processorMid: String,
+    val processorMidType: ProcessorMIDType,
+    val matchingStatus: String, // should be an enum?    // ex:"HISTORIC_TRANSACTION"
+    val rewardDetails: List<RewardDetail>,
+    val createdAt: ZonedDateTime,
+    val updatedAt: ZonedDateTime
+)
+
+enum class TransactionType { CHECK, DEPOSIT, FEE, PAYMENT, PURCHASE, REFUND, TRANSFER, WITHDRAWAL }
+
+enum class ProcessorMIDType {
+    AMEX_SE_NUMBER, DISCOVER_MID, MC_AUTH_LOC_ID, MC_AUTH_ACQ_ID, MC_AUTH_ICA, MC_CLEARING_LOC_ID, MC_CLEARING_ACQ_ID,
+    MC_CLEARING_ICA, MERCHANT_PROCESSOR, NCR, VISA_VMID, VISA_VSID
+}

--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/baseobjects/package-info.java
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/baseobjects/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains example data classes used for prototyping representations of Triple/Coronado API data objects.
+ *
+ * @author Coronado Project Team
+ */
+package io.github.coronado.baseobjects;

--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/package-info.java
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * This package contains the Coronado JVM wrapper for the triple API.
+ *
+ * @author Coronado Project Team
+ */
+package io.github.coronado;

--- a/coronado-triple-api-wrapper/src/test/java/io/github/coronado/api/JavaClientIT.java
+++ b/coronado-triple-api-wrapper/src/test/java/io/github/coronado/api/JavaClientIT.java
@@ -1,0 +1,11 @@
+package io.github.coronado.api;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaClientIT {
+
+    @Test
+    void JavaClientTestStub() {
+        // will test with java code here
+    }
+}

--- a/coronado-triple-api-wrapper/src/test/java/io/github/coronado/baseobjects/BaseObjectsSerializationTest.kt
+++ b/coronado-triple-api-wrapper/src/test/java/io/github/coronado/baseobjects/BaseObjectsSerializationTest.kt
@@ -1,0 +1,319 @@
+package io.github.coronado.baseobjects
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.github.coronado.api.BigDecimalAdapter
+import io.github.coronado.api.CurrencyAdapter
+import io.github.coronado.api.LocalDateAdapter
+import io.github.coronado.api.LocalDateTimeAdapter
+import io.github.coronado.api.LocalTimeAdapter
+import io.github.coronado.api.ZonedDateTimeAdapter
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.util.Currency
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalStdlibApi::class)
+class BaseObjectsSerializationTest {
+
+    lateinit var serializer: Moshi
+
+    @BeforeTest
+    fun initSerializer() {
+        serializer = Moshi.Builder()
+            .add(BigDecimalAdapter)
+            .add(CurrencyAdapter)
+            .add(LocalDateAdapter)
+            .add(LocalDateTimeAdapter)
+            .add(LocalTimeAdapter)
+            .add(ZonedDateTimeAdapter)
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    @Test
+    fun testCurrency() {
+        println("testing currency")
+        val currencyStringValue = "USD"
+        println("currencyStringValue: $currencyStringValue")
+        val currency = Currency.getInstance(currencyStringValue)
+        println("currency: $currency")
+        val currencyDisplayName = currency.displayName
+        println("currency display name: $currencyDisplayName")
+    }
+
+    @Test
+    fun testTransactionSerialization() {
+        val transaction = Transaction(
+            UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+            LocalDate.now(), LocalTime.now(),
+            true,
+            BigDecimal("12.00"), "USD", TransactionType.PURCHASE, "Pittsburgh Zoo",
+            MerchantCategoryCode("7998", "Aquariums, Dolphinariums, Seaquariums, and Zoos"),
+            Address(
+                "7370 BAKER ST STE 100\\nPITTSBURGH, PA 15206",
+                "7370 BAKER ST STE 100", null,
+                "PITTSBURGH", "PA", "15206", "US",
+                BigDecimal(40.440624), BigDecimal(-79.995888)
+            ),
+            "9000012345", ProcessorMIDType.VISA_VMID, "HISTORIC_TRANSACTION",
+            listOf(
+                RewardDetail(
+                    UUID.randomUUID().toString(),
+                    BigDecimal("0.00"),
+                    "USD",
+                    "REJECTED",
+                    "PURCHASE_AMOUNT_TOO_LOW",
+                    "some notes"
+                )
+            ),
+            ZonedDateTime.now(), ZonedDateTime.now()
+        )
+        val transactionJsonAdapter = serializer.adapter<Transaction>().indent("    ")
+        val transactionJson = transactionJsonAdapter.toJson(transaction)
+        println(transactionJson)
+        val roundTripReward = transactionJsonAdapter.fromJson(transactionJson)
+        assertEquals(transaction, roundTripReward)
+        println(roundTripReward)
+    }
+
+    @Test
+    fun testRewardSerialization() {
+        val reward = Reward(
+            UUID.randomUUID().toString(), UUID.randomUUID().toString(), UUID.randomUUID().toString(),
+            ZonedDateTime.now(),
+            "444789", "9876",
+            BigDecimal("12.00"), Currency.getInstance("USD"),
+            BigDecimal("0.00"), "USD",
+            "some offer headline", "some merchant",
+            "7370 BAKER ST STE 100\\nPITTSBURGH, PA 15206",
+            "REJECTED"
+        )
+        val rewardJsonAdapter = serializer.adapter<Reward>().indent("    ")
+        val rewardJson = rewardJsonAdapter.toJson(reward)
+        println(rewardJson)
+        val roundTripReward = rewardJsonAdapter.fromJson(rewardJson)
+        assertEquals(reward, roundTripReward)
+        println(roundTripReward)
+    }
+
+    @Test
+    fun testPublisherSerialization() {
+        val publisher = Publisher(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            "some assumed merchant name",
+            Address(
+                "7370 BAKER ST STE 100\\nPITTSBURGH, PA 15206",
+                "7370 BAKER ST STE 100", null,
+                "PITTSBURGH", "PA", "15206", "US",
+                BigDecimal(40.440624),
+                BigDecimal(-79.995888)
+            ),
+            BigDecimal("1.125"),
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        )
+        val publisherJsonAdapter = serializer.adapter<Publisher>().indent("    ")
+        val publisherJson = publisherJsonAdapter.toJson(publisher)
+        println(publisherJson)
+        val roundTripPublisher = publisherJsonAdapter.fromJson(publisherJson)
+        assertEquals(publisher, roundTripPublisher)
+        println(roundTripPublisher)
+    }
+
+    @Test
+    fun testDisplayRulesSerialization() {
+        val displayRules = DisplayRules(
+            UUID.randomUUID().toString(),
+            "some description",
+            true,
+            DisplayRuleScope(UUID.randomUUID().toString(), "some scope level", "some scope name"),
+            "MERCHANT_NAME_EQUAL_TO",
+            "some value",
+            "EXCLUDE"
+        )
+        val displayRulesJsonAdapter = serializer.adapter<DisplayRules>().indent("    ")
+        val displayRulesJson = displayRulesJsonAdapter.toJson(displayRules)
+        println(displayRulesJson)
+        val roundTripDisplayRules = displayRulesJsonAdapter.fromJson(displayRulesJson)
+        assertEquals(displayRules, roundTripDisplayRules)
+        println(roundTripDisplayRules)
+    }
+
+    @Test
+    fun testOfferSerialization() {
+        val offer = Offer(
+            UUID.randomUUID().toString(),
+            true,
+            0,
+            Currency.getInstance("USD"),
+            "AUTOMOTIVE",
+            "ACategoryTag",
+            setOf("categoryMCC1", "categoryMCC2", "categoryMCC3"),
+            "some offer for something",
+            "2021-12-01",
+            emptySet(),
+            "2021-12-31",
+            false,
+            "Some Offer Headline",
+            "1/3M",
+            0,
+            0,
+            MerchantCategoryCode("7998", "Aquariums, Dolphinariums, Seaquariums, and Zoos"),
+            "Some Merchant",
+            "https://somelogo.com/logo.png?w=120&h=24",
+            BigDecimal.ZERO,
+            "online",
+            0,
+            BigDecimal.ZERO,
+            "CARD_LINKED",
+            "CARD_LINKED",
+            "",
+            "Ts&Cs",
+            "https://somemerch.com/"
+        )
+        val offerJsonAdapter = serializer.adapter<Offer>().indent("  ")
+        val offerJson = offerJsonAdapter.toJson(offer)
+        println(offerJson)
+        val roundTripOffer = offerJsonAdapter.fromJson(offerJson)
+        assertEquals(offer, roundTripOffer)
+        println(roundTripOffer)
+
+        val offerActivation = OfferActivation(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            "2019-08-24",
+            "2019-08-24",
+            offer,
+            "someMerchant, but with a name and logo"
+        )
+        val offerActivationJsonAdapter = serializer.adapter<OfferActivation>().indent("  ")
+        val offerActivationJson = offerActivationJsonAdapter.toJson(offerActivation)
+        println(offerActivationJson)
+        val roundTripofferActivation = offerActivationJsonAdapter.fromJson(offerActivationJson)
+        assertEquals(offerActivation, roundTripofferActivation)
+        println(roundTripofferActivation)
+    }
+
+    @Test
+    fun testMerchantLocationSerialization() {
+        val merchantLocation = MerchantLocation(
+            UUID.randomUUID().toString(),
+            "Some Merchant Downtown",
+            false,
+            "some.merchant@downtown",
+            "555-123-9876",
+            Address(
+                "7370 BAKER ST STE 100\\nPITTSBURGH, PA 15206",
+                "7370 BAKER ST STE 100", null,
+                "PITTSBURGH", "PA", "15206", "US",
+                BigDecimal(40.440624), BigDecimal(-79.995888)
+            )
+        )
+        val merchantLocationJsonAdapter = serializer.adapter<MerchantLocation>().indent("  ")
+        val merchantLocationJson = merchantLocationJsonAdapter.toJson(merchantLocation)
+        println(merchantLocationJson)
+        val roundTripMerchantLocation = merchantLocationJsonAdapter.fromJson(merchantLocationJson)
+        assertEquals(merchantLocation, roundTripMerchantLocation)
+        println(roundTripMerchantLocation)
+    }
+
+    @Test
+    fun testMerchantCategoryCodeSerialization() {
+        val merchantCategoryCode = MerchantCategoryCode("7998", "Aquariums, Dolphinariums, Seaquariums, and Zoos")
+        val merchantCategoryCodeJsonAdapter = serializer.adapter<MerchantCategoryCode>().indent("  ")
+        val merchantCategoryCodeJson = merchantCategoryCodeJsonAdapter.toJson(merchantCategoryCode)
+        println(merchantCategoryCodeJson)
+        val roundTripMerchantCategoryCode = merchantCategoryCodeJsonAdapter.fromJson(merchantCategoryCodeJson)
+        assertEquals(merchantCategoryCode, roundTripMerchantCategoryCode)
+        println(roundTripMerchantCategoryCode)
+    }
+
+    @Test
+    fun testCardProgramSerialization() {
+        val cardProgram = CardProgram(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            "Great Card Program",
+            Currency.getInstance("USD"),
+            setOf("bin1", "bin2"),
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        )
+        val cardProgramJsonAdapter = serializer.adapter<CardProgram>().indent("  ")
+        val cardProgramJson = cardProgramJsonAdapter.toJson(cardProgram)
+        println(cardProgramJson)
+        val roundTripCardProgram = cardProgramJsonAdapter.fromJson(cardProgramJson)
+        assertEquals(cardProgram, roundTripCardProgram)
+        println(roundTripCardProgram)
+    }
+
+    @Test
+    fun testCardAccountSerialization() {
+        val cardAccount = CardAccount(
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            UUID.randomUUID().toString(),
+            CardAccountStatus.ENROLLED,
+            ZonedDateTime.now(),
+            ZonedDateTime.now()
+        )
+        val cardAccountJsonAdapter = serializer.adapter<CardAccount>().indent("  ")
+        val cardAccountJson = cardAccountJsonAdapter.toJson(cardAccount)
+        println(cardAccountJson)
+        val roundTripCardAccount = cardAccountJsonAdapter.fromJson(cardAccountJson)
+        assertEquals(cardAccount, roundTripCardAccount)
+        println(roundTripCardAccount)
+
+        val cardAccountIdentifier = CardAccountIdentifier(
+            UUID.randomUUID().toString(),
+            cardAccount.cardProgramId,
+            cardAccount.cardAccountExternalId,
+            cardAccount.status
+        )
+        val cardAccountIdentifierJsonAdapter = serializer.adapter<CardAccountIdentifier>().indent("  ")
+        val cardAccountIdentifierJson = cardAccountIdentifierJsonAdapter.toJson(cardAccountIdentifier)
+        println(cardAccountIdentifierJson)
+        val roundTripCardAccountIdentifier = cardAccountIdentifierJsonAdapter.fromJson(cardAccountIdentifierJson)
+        assertEquals(cardAccountIdentifier, roundTripCardAccountIdentifier)
+        println(roundTripCardAccountIdentifier)
+
+        val cardAccountIdentifierJson2 = """
+            {
+              "publisherExternalId": "7d5e8d0b-6820-4c6e-a1ea-92a58caa3911",
+              "cardProgramExternalId": "e31396cd-f0f1-4fac-999c-845afa2e27a0",
+              "externalId": "4a72a7e2-7957-4813-80d7-b2ac0c8a27be",
+              "status": "ENROLLED"
+            }
+        """.trimIndent()
+        println("cardAccountIdentifierJson2:\n$cardAccountIdentifierJson2\n")
+        val cardAccountIdentifier2 = cardAccountIdentifierJsonAdapter.fromJson(cardAccountIdentifierJson2)
+        println("cardAccountIdentifier2:\n$cardAccountIdentifier2\n")
+    }
+
+    @Test
+    fun testAddressSerialization() {
+        val testAddress = Address(
+            "7370 BAKER ST STE 100\\nPITTSBURGH, PA 15206",
+            "7370 BAKER ST STE 100", null,
+            "PITTSBURGH", "PA", "15206", "US",
+            BigDecimal(40.440624), BigDecimal(-79.995888)
+        )
+        val addressJsonAdapter = serializer.adapter<Address>().indent("  ")
+        val addressJson = addressJsonAdapter.toJson(testAddress)
+        println(addressJson)
+
+        val roundTripAddress = addressJsonAdapter.fromJson(addressJson)
+        assertEquals(testAddress, roundTripAddress)
+        println(roundTripAddress)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
         </developer>
     </developers>
 
+    <modules>
+        <module>coronado-triple-api-wrapper</module>
+    </modules>
+
     <scm>
         <url>https://github.com/coronado-fi/coronado-jvm</url>
         <connection>scm:git:https://github.com/coronado-fi/coronado-jvm</connection>


### PR DESCRIPTION
- established api wrapper module
- created base object representations analogous to coronado python codebase
- added json adapters for handling json serializations
- created unit test for base object serialization to/from json
- created stub java client integration test

Signed-off-by: Phillip Ross (Numo OSS) <phillip.ross@numo.com>