### PR TITLE
FIX: change "endpoint" client config property name to "serviceDomain"

### DIFF
--- a/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/Client.kt
+++ b/coronado-triple-api-wrapper/src/main/java/io/github/coronado/api/Client.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 import java.util.Base64
 
 class Client private constructor(
-    val endpoint: String?,
+    val serviceDomain: String?,
     val clientId: String?,
     val clientSecret: String?,
     val scope: OAuth2Scope?,
@@ -20,14 +20,14 @@ class Client private constructor(
 ) {
     // Validated state in initializer
     init {
-        if (endpoint == null) { throw IllegalArgumentException("endpoint must not be null") }
+        if (serviceDomain == null) { throw IllegalArgumentException("endpoint must not be null") }
         if (clientId == null) { throw IllegalArgumentException("clientId must not be null") }
         if (clientSecret == null) { throw IllegalArgumentException("clientSecret must not be null") }
         if (scope == null) { throw IllegalArgumentException("scope must not be null") }
     }
 
-    val tokenUrl = "https://auth.$endpoint/oauth2/token"
-    val apiUrl = "https://api.$endpoint/"
+    val tokenUrl = "https://auth.$serviceDomain/oauth2/token"
+    val apiUrl = "https://api.$serviceDomain/"
     val httpClient = HttpClient.newBuilder().build()
 
     var jwt = emptyMap<String, String>()
@@ -36,18 +36,18 @@ class Client private constructor(
     private var tokenType = ""
 
     data class Builder(
-        var endpoint: String? = null,
+        var serviceDomain: String? = null,
         var clientId: String? = null,
         var clientSecret: String? = null,
         var scope: OAuth2Scope? = null,
         var ttl: Long? = null
     ) {
-        fun endpoint(endpoint: String) = apply { this.endpoint = endpoint }
+        fun serviceDomain(serviceDomain: String) = apply { this.serviceDomain = serviceDomain }
         fun clientId(clientId: String) = apply { this.clientId = clientId }
         fun clientSecret(clientSecret: String) = apply { this.clientSecret = clientSecret }
         fun scope(scope: OAuth2Scope) = apply { this.scope = scope }
         fun ttl(ttl: Long) = apply { this.ttl = ttl }
-        fun build() = Client(endpoint, clientId, clientSecret, scope, ttl)
+        fun build() = Client(serviceDomain, clientId, clientSecret, scope, ttl)
     }
 
     enum class OAuth2Scope {

--- a/coronado-triple-api-wrapper/src/test/java/io/github/coronado/api/ClientIT.kt
+++ b/coronado-triple-api-wrapper/src/test/java/io/github/coronado/api/ClientIT.kt
@@ -6,27 +6,29 @@ import kotlin.test.assertNotEquals
 
 class ClientIT {
 
-    val cfgNameTripleApiEndpoint = "TRIPLE_API_ENDPOINT"
+    val jwtAccessTokenPropertyName = "access_token"
+    val jwtTokenTypePropertyName = "token_type"
+    val cfgNameTripleApiServiceDomain = "TRIPLE_API_SERVICE_DOMAIN"
     val cfgNameTripleApiClientId = "TRIPLE_API_CLIENT_ID"
     val cfgNameTripleApiClientSecret = "TRIPLE_API_CLIENT_SECRET"
     val config = mapOf(
-        "endpoint" to System.getenv()[cfgNameTripleApiEndpoint]!!,
-        "clientId" to System.getenv()[cfgNameTripleApiClientId]!!,
-        "clientSecret" to System.getenv()[cfgNameTripleApiClientSecret]!!
+        cfgNameTripleApiServiceDomain to System.getenv()[cfgNameTripleApiServiceDomain]!!,
+        cfgNameTripleApiClientId to System.getenv()[cfgNameTripleApiClientId]!!,
+        cfgNameTripleApiClientSecret to System.getenv()[cfgNameTripleApiClientSecret]!!
     )
 
     @Test // @Ignore("This test needs real credentials and makes live connections to an endpoint")
     fun `test auth with varied scopes`() {
         Client.OAuth2Scope.values().forEach {
             val client = Client.Builder()
-                .endpoint(config["endpoint"]!!)
-                .clientId(config["clientId"]!!)
-                .clientSecret(config["clientSecret"]!!)
+                .serviceDomain(config[cfgNameTripleApiServiceDomain]!!)
+                .clientId(config[cfgNameTripleApiClientId]!!)
+                .clientSecret(config[cfgNameTripleApiClientSecret]!!)
                 .scope(it)
                 .build()
-            assertEquals(client.endpoint, config["endpoint"]!!)
-            assertEquals(client.clientId, config["clientId"]!!)
-            assertEquals(client.clientSecret, config["clientSecret"]!!)
+            assertEquals(client.serviceDomain, config[cfgNameTripleApiServiceDomain]!!)
+            assertEquals(client.clientId, config[cfgNameTripleApiClientId]!!)
+            assertEquals(client.clientSecret, config[cfgNameTripleApiClientSecret]!!)
             assertEquals(it, client.scope)
         }
     }
@@ -34,9 +36,9 @@ class ClientIT {
     @Test // @Ignore("This test needs real credentials and makes live connections to an endpoint")
     fun `test auth expired tokens`() {
         val clientA = Client.Builder()
-            .endpoint(config["endpoint"]!!)
-            .clientId(config["clientId"]!!)
-            .clientSecret(config["clientSecret"]!!)
+            .serviceDomain(config[cfgNameTripleApiServiceDomain]!!)
+            .clientId(config[cfgNameTripleApiClientId]!!)
+            .clientSecret(config[cfgNameTripleApiClientSecret]!!)
             .scope(Client.OAuth2Scope.PARTNER_CONTENT_PROVIDERS)
             .build()
         val oldTokenA = clientA.token()
@@ -45,9 +47,9 @@ class ClientIT {
         assertEquals(oldTokenA, newTokenA)
 
         val clientB = Client.Builder()
-            .endpoint(config["endpoint"]!!)
-            .clientId(config["clientId"]!!)
-            .clientSecret(config["clientSecret"]!!)
+            .serviceDomain(config[cfgNameTripleApiServiceDomain]!!)
+            .clientId(config[cfgNameTripleApiClientId]!!)
+            .clientSecret(config[cfgNameTripleApiClientSecret]!!)
             .scope(Client.OAuth2Scope.PARTNER_CONTENT_PROVIDERS)
             .ttl(2)
             .build()
@@ -60,26 +62,26 @@ class ClientIT {
     @Test // @Ignore("This test needs real credentials and makes live connections to an endpoint")
     fun `test access tokens`() {
         val client = Client.Builder()
-            .endpoint(config["endpoint"]!!)
-            .clientId(config["clientId"]!!)
-            .clientSecret(config["clientSecret"]!!)
+            .serviceDomain(config[cfgNameTripleApiServiceDomain]!!)
+            .clientId(config[cfgNameTripleApiClientId]!!)
+            .clientSecret(config[cfgNameTripleApiClientSecret]!!)
             .scope(Client.OAuth2Scope.PARTNER_PUBLISHERS)
             .build()
         client.tokenPayload()
-        val control = client.jwt["access_token"]!!
+        val control = client.jwt[jwtAccessTokenPropertyName]!!
         assertEquals(client.accessToken, control)
     }
 
     @Test // @Ignore("This test needs real credentials and makes live connections to an endpoint")
     fun `test token type`() {
         val client = Client.Builder()
-            .endpoint(config["endpoint"]!!)
-            .clientId(config["clientId"]!!)
-            .clientSecret(config["clientSecret"]!!)
+            .serviceDomain(config[cfgNameTripleApiServiceDomain]!!)
+            .clientId(config[cfgNameTripleApiClientId]!!)
+            .clientSecret(config[cfgNameTripleApiClientSecret]!!)
             .scope(Client.OAuth2Scope.PARTNER_PUBLISHERS)
             .build()
         client.tokenPayload()
-        val control = client.jwt["token_type"]!!
+        val control = client.jwt[jwtTokenTypePropertyName]!!
         assertEquals(client.tokenType(), control)
     }
 }


### PR DESCRIPTION
- FIX: change "endpoint" client config property name to "serviceDomain"

Signed-off-by: Phillip Ross (Numo OSS) <phillip.ross@numo.com>